### PR TITLE
Investigate and fix DynamoDB update error

### DIFF
--- a/lambdas/post_notify/app.py
+++ b/lambdas/post_notify/app.py
@@ -205,9 +205,12 @@ def record_notified(video_id: str, title: str, url: str, thumbnail_url: str) -> 
         "SET notified_timestamp = :notified_timestamp, "
         "is_notified = :is_notified, "
         "title = :title, "
-        "url = :url, "
+        "#url = :url, "
         "thumbnail_url = :thumbnail_url"
     )
+    expression_attribute_names: Dict[str, str] = {
+        "#url": "url"
+    }
     expression_attribute_values: Dict[str, Any] = {
         ":notified_timestamp": {"N": str(int(time.time()))},
         ":is_notified": {"BOOL": True},
@@ -219,6 +222,7 @@ def record_notified(video_id: str, title: str, url: str, thumbnail_url: str) -> 
         TableName=DYNAMODB_TABLE,
         Key={"video_id": {"S": video_id}},
         UpdateExpression=update_expression,
+        ExpressionAttributeNames=expression_attribute_names,
         ExpressionAttributeValues=expression_attribute_values,
     )
 

--- a/tests/post_notify/test_app.py
+++ b/tests/post_notify/test_app.py
@@ -437,7 +437,26 @@ class TestRecordNotified:
                     "test_video_id", "Test Title", "test_url", "test_thumbnail"
                 )
 
-                mock_dynamodb_client.update_item.assert_called_once()
+                # DynamoDB update_item が正しい引数で呼び出されることを検証
+                mock_dynamodb_client.update_item.assert_called_once_with(
+                    TableName="test-dynamodb-table",
+                    Key={"video_id": {"S": "test_video_id"}},
+                    UpdateExpression=(
+                        "SET notified_timestamp = :notified_timestamp, "
+                        "is_notified = :is_notified, "
+                        "title = :title, "
+                        "#url = :url, "
+                        "thumbnail_url = :thumbnail_url"
+                    ),
+                    ExpressionAttributeNames={"#url": "url"},
+                    ExpressionAttributeValues={
+                        ":notified_timestamp": {"N": "1234567890"},
+                        ":is_notified": {"BOOL": True},
+                        ":title": {"S": "Test Title"},
+                        ":url": {"S": "test_url"},
+                        ":thumbnail_url": {"S": "test_thumbnail"},
+                    },
+                )
 
 
 @patch.dict(


### PR DESCRIPTION
Alias 'url' attribute in DynamoDB UpdateExpression to fix `ValidationException` caused by 'url' being a reserved keyword.