### PR TITLE
ci: Dependabot向けビルドとPR向けテスト・Lintワークフローを追加

### DIFF
--- a/.github/workflows/dependabot-lambda-build.yml
+++ b/.github/workflows/dependabot-lambda-build.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python 3.12 Environment
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/dependabot-lambda-build.yml
+++ b/.github/workflows/dependabot-lambda-build.yml
@@ -1,0 +1,44 @@
+name: Dependabot Lambda Build
+
+on:
+  pull_request:
+    paths:
+      - requirements.txt
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-lambda-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lambda-build:
+    name: SAM Lambda Build
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Copy requirements to Lambda directories
+        run: |
+          for dir in get_notify post_notify websub post_pipeline layer; do
+            cp requirements.txt "lambdas/${dir}/requirements.txt"
+          done
+
+      - name: Build Lambda functions
+        run: sam build --template templates/sam.yml

--- a/.github/workflows/test-lint-lambdas.yaml
+++ b/.github/workflows/test-lint-lambdas.yaml
@@ -1,14 +1,13 @@
-name: Run Tests, Lint and Package Lambda Functions before Merging Pull Request
+name: Run Tests and Lint in Lambda Functions before Merging Pull Request
 
 on:
   pull_request:
     branches:
       - main
     paths:
-      - .github/workflows/test-lint-package-lambdas.yaml
+      - .github/workflows/test-lint-lambdas.yaml
       - lambdas/**
       - requirements.txt
-      - templates/sam.yml
       - pytest.ini
 
 env:
@@ -64,43 +63,3 @@ jobs:
 
       - name: Run lint
         run: pylint lambdas/**/*.py
-
-  package:
-    needs: [test, lint]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Python ${{ env.PYTHON_VERSION }} Environment
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: pip
-          cache-dependency-path: requirements.txt
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Copy requirements to Lambda directories
-        run: |
-          for dir in get_notify post_notify websub post_pipeline layer; do
-            cp requirements.txt "lambdas/${dir}/requirements.txt"
-          done
-
-      - name: Build Lambda functions
-        run: sam build --template templates/sam.yml
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_ARN_IAM_ROLE_GITHUB_ACTIONS }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
-
-      - name: Package Lambda functions
-        run: sam package --s3-bucket ${{ vars.ARTIFACT_S3_BUCKET_NAME }} --output-template-file packaged.yaml

--- a/.github/workflows/test-lint-package-lambdas.yaml
+++ b/.github/workflows/test-lint-package-lambdas.yaml
@@ -1,0 +1,106 @@
+name: Run Tests, Lint and Package Lambda Functions before Merging Pull Request
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/test-lint-package-lambdas.yaml
+      - lambdas/**
+      - requirements.txt
+      - templates/sam.yml
+      - pytest.ini
+
+env:
+  PYTHON_VERSION: "3.12"
+  AWS_DEFAULT_REGION: ap-northeast-1
+  PYTHONPATH: lambdas/layer/python
+
+permissions:
+  checks: write
+  pull-requests: write
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }} Environment
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run unittests with coverage
+        run: |
+          pytest --cov=lambdas --cov-report=term-missing --cov-fail-under=80 lambdas/tests
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }} Environment
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run lint
+        run: pylint lambdas/**/*.py
+
+  package:
+    needs: [test, lint]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }} Environment
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Copy requirements to Lambda directories
+        run: |
+          for dir in get_notify post_notify websub post_pipeline layer; do
+            cp requirements.txt "lambdas/${dir}/requirements.txt"
+          done
+
+      - name: Build Lambda functions
+        run: sam build --template templates/sam.yml
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ARN_IAM_ROLE_GITHUB_ACTIONS }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Package Lambda functions
+        run: sam package --s3-bucket ${{ vars.ARTIFACT_S3_BUCKET_NAME }} --output-template-file packaged.yaml


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

GitHub Actions ワークフローを追加しました。1つは Dependabot の `requirements.txt` 更新 PR 向けの Lambda ビルド検証、もう1つは通常の Pull Request 向けのテスト・pylint 実行です。

## 変更内容

### `.github/workflows/dependabot-lambda-build.yml`
- Dependabot PR（`requirements.txt` 変更）で `sam build` のみ実行
- `actions/checkout@v7` / `actions/setup-python@v6` を使用

### `.github/workflows/test-lint-lambdas.yaml`
- トリガー: `main` 向け PR で `lambdas/**` 等の関連ファイルが変更された場合
- ジョブ構成:
  - **test**: `pytest`（カバレッジ 80% 以上）
  - **lint**: `pylint lambdas/**/*.py`
- `MarkdownNotePortal` の `test-lint-lambdas.yaml` と同様の構成・命名

## テスト内容

- ローカルで `pytest`（カバレッジ 80% 以上）・`pylint` が成功することを確認
- ワークフロー YAML の構文検証を実施

## 関連Issue

- なし

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05c425c0-d152-44f9-bf2c-23fe92e7b0d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05c425c0-d152-44f9-bf2c-23fe92e7b0d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

